### PR TITLE
ConsoleReporter Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ MetricExtension supports 4 different reporters: JMX, Graphite, Ganglia and Datad
 | apiKey | API key of Datadog service | Only apply in "http" mode    |
 | statsdHost | StatsD agent host |  Only apply in "udp" mode   |
 | statsdPort | StatsD agent port |  Only apply in "udp" mode   |
+###Console reporter configuration
+| property     | description    | comment |
+| --------|---------|-------|
+| rateUnit  | Rate time unit   | From NANOSECONDS to DAYS defined in Java TimeUnit class    |
+| durationUnit | Duration time unit | From NANOSECONDS to DAYS defined in Java TimeUnit class     |
+| output | PrintStream to use for output |  Default: System.out   |
 
 To Report The Metrics of Orbit Cluster
 -----

--- a/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/ConsoleReporterConfig.java
+++ b/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/ConsoleReporterConfig.java
@@ -1,0 +1,68 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.metrics.dropwizard;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Reporter;
+
+import java.io.PrintStream;
+
+/**
+ * Created by asnyder on 2/2/17.
+ */
+public class ConsoleReporterConfig extends ReporterConfig
+{
+    private PrintStream output = System.out;
+
+    public PrintStream getOutput()
+    {
+        return output;
+    }
+
+    public ConsoleReporterConfig setOutput(final PrintStream output)
+    {
+        this.output = output;
+        return this;
+    }
+
+    @Override
+    public synchronized Reporter enableReporter(final MetricRegistry registry)
+    {
+        final ConsoleReporter reporter = ConsoleReporter.forRegistry(registry)
+                .convertRatesTo(getRateTimeUnit())
+                .convertDurationsTo(getDurationTimeUnit())
+                .outputTo(output)
+                .build();
+
+        reporter.start(getPeriod(), getPeriodTimeUnit());
+
+        return reporter;
+    }
+}


### PR DESCRIPTION
Adds support for ConsoleReporter to report metrics to console. Useful for dirty local testing. Provides a configuration field for setting the PrintStream to use for output.