### PR TITLE
Fix NullPointerException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,5 +87,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>dropwizard-metrics-datadog</artifactId>
             <version>1.1.6</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtension.java
+++ b/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtension.java
@@ -56,7 +56,7 @@ public class MetricsExtension implements ActorExtension {
     }
 
     public MetricsExtension() {
-
+        MetricsManager.getInstance().setRegistry(new MetricRegistry());
     }
 
     public MetricsExtension(List<ReporterConfig> metricsConfigs) {
@@ -64,6 +64,7 @@ public class MetricsExtension implements ActorExtension {
             throw new IllegalArgumentException("metricsConfigs cannot be null");
         }
         metricsConfig.addAll(metricsConfigs);
+        MetricsManager.getInstance().setRegistry(new MetricRegistry());
     }
 
     @Override

--- a/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsManager.java
+++ b/src/main/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsManager.java
@@ -67,7 +67,6 @@ public class MetricsManager {
 
     public synchronized void initializeMetrics(List<ReporterConfig> reporterConfigs) {
         if (!isInitialized) {
-            registry = new MetricRegistry();
             for (ReporterConfig reporterConfig : reporterConfigs) {
                 Reporter reporter = reporterConfig.enableReporter(registry);
                 if (reporter != null) {

--- a/src/test/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtensionTest.java
+++ b/src/test/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtensionTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -51,5 +52,30 @@ public class MetricsExtensionTest
     public void constructWithConfigs_nullArgument_throws() throws Exception
     {
         new MetricsExtension((List<ReporterConfig>) null);
+    }
+
+    @Test
+    public void constructEmpty_hasRegistry() throws Exception
+    {
+        MetricsManager.getInstance().setRegistry(null);
+        new MetricsExtension();
+        assertNotNull(MetricsManager.getInstance().getRegistry());
+    }
+
+    @Test
+    public void constructWithRegistry_hasRegistry() throws Exception
+    {
+        MetricRegistry registry = new MetricRegistry();
+        MetricsManager.getInstance().setRegistry(null);
+        new MetricsExtension(registry);
+        assertEquals(registry, MetricsManager.getInstance().getRegistry());
+    }
+
+    @Test
+    public void constructWithConfigs_hasRegistry() throws Exception
+    {
+        MetricsManager.getInstance().setRegistry(null);
+        new MetricsExtension(Collections.emptyList());
+        assertNotNull(MetricsManager.getInstance().getRegistry());
     }
 }

--- a/src/test/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtensionTest.java
+++ b/src/test/java/cloud/orbit/actors/extensions/metrics/dropwizard/MetricsExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2016 Electronic Arts Inc.  All rights reserved.
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -28,53 +28,28 @@
 
 package cloud.orbit.actors.extensions.metrics.dropwizard;
 
+import org.junit.Test;
+
 import com.codahale.metrics.MetricRegistry;
 
-import cloud.orbit.actors.extensions.ActorExtension;
-import cloud.orbit.actors.extensions.LifetimeExtension;
-import cloud.orbit.actors.extensions.NamedPipelineExtension;
-import cloud.orbit.concurrent.Task;
-
-import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.*;
+
 /**
- * Created by jgong on 12/15/16.
+ * Created by asnyder on 2/2/17.
  */
-public class MetricsExtension implements ActorExtension {
-    private List<ReporterConfig> metricsConfig = new ArrayList<>();
-
-    /**
-     * Alternative way to construct the extension, client is responsible to setup the
-     * MetricRegistry
-     */
-    public MetricsExtension(MetricRegistry metricRegistry) {
-        if (metricRegistry == null) {
-            throw new IllegalArgumentException("metricRegistry cannot be null");
-        }
-        MetricsManager.getInstance().setRegistry(metricRegistry);
+public class MetricsExtensionTest
+{
+    @Test(expected = IllegalArgumentException.class)
+    public void constructWithRegistry_nullArgument_throws() throws Exception
+    {
+        new MetricsExtension((MetricRegistry) null);
     }
 
-    public MetricsExtension() {
-
+    @Test(expected = IllegalArgumentException.class)
+    public void constructWithConfigs_nullArgument_throws() throws Exception
+    {
+        new MetricsExtension((List<ReporterConfig>) null);
     }
-
-    public MetricsExtension(List<ReporterConfig> metricsConfigs) {
-        if (metricsConfigs == null) {
-            throw new IllegalArgumentException("metricsConfigs cannot be null");
-        }
-        metricsConfig.addAll(metricsConfigs);
-    }
-
-    @Override
-    public Task<?> start() {
-        MetricsManager.getInstance().initializeMetrics(metricsConfig);
-        return Task.done();
-    }
-
-    @Override
-    public Task<?> stop() {
-        return Task.done();
-    }
-
 }


### PR DESCRIPTION
The problem was that MetricRegistry was not being initialized until MetricsExtension's start() method was called, so any metrics that were being registered before start() were throwing NullPointerExceptions.